### PR TITLE
qf_resize#adjust_window_height: handle non-existing winnr

### DIFF
--- a/autoload/qf_resize.vim
+++ b/autoload/qf_resize.vim
@@ -81,6 +81,9 @@ function! qf_resize#adjust_window_height(...) abort
   let cur_win = a:0 ? a:1 : winnr()
   call s:log('Called for window '.cur_win
         \ .'; window layout: '.string(map(range(1, winnr('$')), 'winheight(v:val)')))
+  if cur_win > winnr('$') || cur_win < 1
+    return
+  endif
 
   if !exists('b:_qf_resize_seen')
     let b:_qf_resize_seen = 1

--- a/test/qf_resize.vader
+++ b/test/qf_resize.vader
@@ -276,3 +276,6 @@ Execute (Handles processing from another window):
   if g:qf_resize_use_feedkeys | call feedkeys('', 'x') | endif
 
   AssertEqual winheight(2), 2
+
+Execute (Handles processing with non-existing window):
+  call qf_resize#adjust_window_height(10000)


### PR DESCRIPTION
This can happen when using the feedkeys method, and the window is closed
already when the function is called.